### PR TITLE
ie fix

### DIFF
--- a/lib/passport-http/strategies/digest.js
+++ b/lib/passport-http/strategies/digest.js
@@ -231,13 +231,11 @@ DigestStrategy.prototype._challenge = function() {
  * @api private
  */
 function parse(params) {
-  params = params.replace(/(( |^)\w+)=([^," ]+)/g, '$1=\"$3\"');
-  
   var opts = {};
-  var tokens = params.match(/(\w+)="([^"]+)"/g);
+  var tokens = params.split(/,(?=(?:[^"]|"[^"]*")*$)/);
   if (tokens) {
     for (var i = 0, len = tokens.length; i < len; i++) {
-      var param = /(\w+)="([^"]+)"/.exec(tokens[i])
+      var param = /(\w+)=["]?([^"]+)["]?$/.exec(tokens[i])
       opts[param[1]] = param[2];
     }
   }


### PR DESCRIPTION
IE doesn't use spaces to seperate items.  Switch to two regexs.  Tested on multiple modern browsers.
