### PR TITLE
Added passReqToCallback option to the BasicStrategy

### DIFF
--- a/lib/passport-http/strategies/basic.js
+++ b/lib/passport-http/strategies/basic.js
@@ -49,6 +49,7 @@ function BasicStrategy(options, verify) {
   this.name = 'basic';
   this._verify = verify;
   this._realm = options.realm || 'Users';
+  this._passReqToCallback = options.passReqToCallback;
 }
 
 /**
@@ -82,11 +83,19 @@ BasicStrategy.prototype.authenticate = function(req) {
   }
   
   var self = this;
-  this._verify(userid, password, function(err, user) {
-    if (err) { return self.error(err); }
-    if (!user) { return self.fail(self._challenge()); }
-    self.success(user);
-  });
+  if (self._passReqToCallback) {
+    this._verify(req, userid, password, function(err, user) {
+      if (err) { return self.error(err); }
+      if (!user) { return self.fail(self._challenge()); }
+      self.success(user);
+    });
+  } else {
+    this._verify(userid, password, function(err, user) {
+      if (err) { return self.error(err); }
+      if (!user) { return self.fail(self._challenge()); }
+      self.success(user);
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
passReqToCallback pass the req object to the callback. Making this similar to other passport Strategies like http-bearer.
