### PR TITLE
Fixed issue where submitting empty string for username in Digest auth will return a 400, instead of a 401. Added empty user test case.

### DIFF
--- a/lib/passport-http/strategies/digest.js
+++ b/lib/passport-http/strategies/digest.js
@@ -107,10 +107,11 @@ DigestStrategy.prototype.authenticate = function(req) {
   if (!/Digest/i.test(scheme)) { return this.fail(this._challenge()); }
   
   var creds = parse(params);
-  
+/* Removed by David Podolsky. Ref issue #9 
   if (!creds.username) {
     return this.fail(400);
   }
+*/
   if (req.url !== creds.uri) {
     return this.fail(400);
   }

--- a/test/strategies/digest-test.js
+++ b/test/strategies/digest-test.js
@@ -60,6 +60,49 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
+
+
+  'strategy handling a valid request with an empty username': {
+    topic: function() {
+      var strategy = new DigestStrategy(
+        function(username, done) {
+          done(null, { username: username }, 'secret');
+        },
+        function(options, done) {
+          done(null, true);
+        }
+      );
+      return strategy;
+    },
+    
+    'after augmenting with actions': {
+      topic: function(strategy) {
+        var self = this;
+        var req = {};
+        strategy.success = function(user) {
+          self.callback(null, user);
+        }
+        strategy.fail = function() {
+          self.callback(new Error('should not be called'));
+        }
+        
+        req.url = '/';
+        req.method = 'HEAD';
+        req.headers = {};
+        req.headers.authorization = 'Digest username="", realm="Users", nonce="NOIEDJ3hJtqSKaty8KF8xlkaYbItAkiS", uri="/", response="459ea26315b4ac2ad14537695acd5a9b"';
+        process.nextTick(function () {
+          strategy.authenticate(req);
+        });
+      },
+      
+      'should not generate an error' : function(err, user) {
+        assert.isNull(err);
+      },
+      'should authenticate' : function(err, user) {
+        assert.equal(user.username, undefined);
+      },
+    },
+  },
   
   'strategy handling a valid request with credentials not separated by spaces': {
     topic: function() {


### PR DESCRIPTION
https://github.com/jaredhanson/passport-http/issues/9
"Submitting empty string for username in Digest auth will return a 400, instead of a 401."

Added test case to validate empty username
