### PR TITLE
return 401 instead of 400 if no password or username is provided

### DIFF
--- a/lib/passport-http/strategies/basic.js
+++ b/lib/passport-http/strategies/basic.js
@@ -78,7 +78,7 @@ BasicStrategy.prototype.authenticate = function(req) {
   var userid = credentials[0];
   var password = credentials[1];
   if (!userid || !password) {
-    return this.fail(400);
+    return this.fail(401);
   }
   
   var self = this;


### PR DESCRIPTION
Like in #9 the basic auth strategy also returns a 400 code when no password or username is provided. The same browser cache issues arise as in the digest strategy.

I'm wondering why this check is here in the first place. Shouldn't  this be the decision of the user in the `verify` callback?
