### PR TITLE
Allow Digest strategy to work with mounted apps

### DIFF
--- a/lib/passport-http/strategies/digest.js
+++ b/lib/passport-http/strategies/digest.js
@@ -66,7 +66,7 @@ function DigestStrategy(options, secret, validate) {
     options = {};
   }
   if (!secret) throw new Error('HTTP Digest authentication strategy requires a secret function');
-  
+
   passport.Strategy.call(this);
   this.name = 'digest';
   this._secret = secret;
@@ -97,18 +97,18 @@ util.inherits(DigestStrategy, passport.Strategy);
 DigestStrategy.prototype.authenticate = function(req) {
   var authorization = req.headers['authorization'];
   if (!authorization) { return this.fail(this._challenge()); }
-  
+
   var parts = authorization.split(' ')
   if (parts.length < 2) { return this.fail(400); }
-  
+
   var scheme = parts[0]
     , params = parts.slice(1).join(' ');
-  
+
   if (!/Digest/i.test(scheme)) { return this.fail(this._challenge()); }
-  
+
   var creds = parse(params);
   if (Object.keys(creds).length === 0) { return this.fail(400); }
-  
+
   if (!creds.username) {
     return this.fail(this._challenge());
   }
@@ -117,10 +117,10 @@ DigestStrategy.prototype.authenticate = function(req) {
   if (url !== creds.uri) {
     return this.fail(400);
   }
-  
-  
+
+
   var self = this;
-  
+
   // Use of digest authentication requires a password (aka shared secret) known
   // to both the client and server, but not transported over the wire.  This
   // secret is needed in order to compute the hashes required to authenticate
@@ -133,7 +133,7 @@ DigestStrategy.prototype.authenticate = function(req) {
   this._secret(creds.username, function(err, user, password) {
     if (err) { return self.error(err); }
     if (!user) { return self.fail(self._challenge()); }
-    
+
     var ha1;
     if (!creds.algorithm || creds.algorithm === 'MD5') {
       if (typeof password === 'object' && password.ha1) {
@@ -153,7 +153,7 @@ DigestStrategy.prototype.authenticate = function(req) {
     } else {
       return self.fail(400);
     }
-    
+
     var ha2;
     if (!creds.qop || creds.qop === 'auth') {
       ha2 = md5(req.method + ":" + creds.uri);
@@ -168,7 +168,7 @@ DigestStrategy.prototype.authenticate = function(req) {
     } else {
       return self.fail(400);
     }
-    
+
     var digest;
     if (!creds.qop) {
       digest = md5(ha1 + ":" + creds.nonce + ":" + ha2);
@@ -177,7 +177,7 @@ DigestStrategy.prototype.authenticate = function(req) {
     } else {
       return self.fail(400);
     }
-    
+
     if (creds.response != digest) {
       return self.fail(self._challenge());
     } else {
@@ -208,7 +208,7 @@ DigestStrategy.prototype.authenticate = function(req) {
 DigestStrategy.prototype._challenge = function() {
   // TODO: For maximum flexibility, a mechanism for delegating the generation
   //       of the nonce and opaque data to the application would be useful.
-  
+
   var challenge = 'Digest realm="' + this._realm + '"';
   if (this._domain) {
     challenge += ', domain="' + this._domain.join(' ') + '"';
@@ -223,7 +223,7 @@ DigestStrategy.prototype._challenge = function() {
   if (this._qop) {
     challenge += ', qop="' + this._qop.join(',') + '"';
   }
-  
+
   return challenge;
 }
 
@@ -296,5 +296,5 @@ function md5(str, encoding){
 
 /**
  * Expose `DigestStrategy`.
- */ 
+ */
 module.exports = DigestStrategy;

--- a/lib/passport-http/strategies/digest.js
+++ b/lib/passport-http/strategies/digest.js
@@ -112,7 +112,9 @@ DigestStrategy.prototype.authenticate = function(req) {
   if (!creds.username) {
     return this.fail(this._challenge());
   }
-  if (req.originalUrl !== creds.uri) {
+
+  var url = req.originalUrl || req.url;
+  if (url !== creds.uri) {
     return this.fail(400);
   }
   

--- a/lib/passport-http/strategies/digest.js
+++ b/lib/passport-http/strategies/digest.js
@@ -112,7 +112,7 @@ DigestStrategy.prototype.authenticate = function(req) {
   if (!creds.username) {
     return this.fail(this._challenge());
   }
-  if (req.url !== creds.uri) {
+  if (req.originalUrl !== creds.uri) {
     return this.fail(400);
   }
   

--- a/test/strategies/digest-test.js
+++ b/test/strategies/digest-test.js
@@ -5,7 +5,7 @@ var DigestStrategy = require('passport-http/strategies/digest');
 
 
 vows.describe('DigestStrategy').addBatch({
-  
+
   'strategy': {
     topic: function() {
       return new DigestStrategy(
@@ -13,12 +13,12 @@ vows.describe('DigestStrategy').addBatch({
         function() {}
       );
     },
-    
+
     'should be named digest': function (strategy) {
       assert.equal(strategy.name, 'digest');
     },
   },
-  
+
   'strategy handling a valid request': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -31,7 +31,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -42,7 +42,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function() {
           self.callback(new Error('should not be called'));
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -51,7 +51,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -61,6 +61,55 @@ vows.describe('DigestStrategy').addBatch({
     },
   },
 
+  'strategy handling a valid request to a mounted app': {
+    topic: function() {
+      var strategy = new DigestStrategy({ qop: 'auth' },
+        function(username, done) {
+          done(null, { username: username }, 'secret');
+        },
+        function(options, done) {
+          if (options.nonce === '3sauEztFK9HB2vjADmXE4sQbtwpGCFZ2' && options.cnonce === 'MTM0MTkw' && options.nc === '00000001') {
+            done(null, { nonce: options.nonce, cnonce: options.cnonce, nc: options.nc });
+          } else {
+            done(new Error('something is wrong'))
+          }
+        }
+      );
+      return strategy;
+    },
+
+    'after augmenting with actions': {
+      topic: function(strategy) {
+        var self = this;
+        var req = {};
+        strategy.success = function(user) {
+          self.callback(null, user);
+        }
+        strategy.fail = function() {
+          self.callback(new Error('should not be called'));
+        }
+        strategy.error = function() {
+          self.callback(new Error('should not be called'));
+        }
+
+        req.originalUrl = '/sessions.json?sEcho=2&iColumns=12';
+        req.url = '/?sEcho=2&iColumns=12';
+        req.method = 'HEAD';
+        req.headers = {};
+        req.headers.authorization = 'Digest username="bob", realm="Users", nonce="3sauEztFK9HB2vjADmXE4sQbtwpGCFZ2", uri="/sessions.json?sEcho=2&iColumns=12", cnonce="MTM0MTkw", nc=00000001, qop="auth", response="83e2cb1afbb943a0cde78290c5002607"';
+        process.nextTick(function () {
+          strategy.authenticate(req);
+        });
+      },
+
+      'should not generate an error' : function(err, user) {
+        assert.isNull(err);
+      },
+      'should authenticate' : function(err, user) {
+        assert.equal(user.username, 'bob');
+      },
+    },
+  },
 
   'strategy handling a valid request with an empty username': {
     topic: function() {
@@ -74,7 +123,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -85,7 +134,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -94,7 +143,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -103,7 +152,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a valid request with credentials not separated by spaces': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -116,7 +165,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -127,7 +176,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function() {
           self.callback(new Error('should not be called'));
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -136,7 +185,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -145,7 +194,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a valid request and supplying hashed HA1 to secret callback': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -158,7 +207,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -169,7 +218,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function() {
           self.callback(new Error('should not be called'));
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -178,7 +227,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -187,7 +236,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a valid request without optional validate callback': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -197,7 +246,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -208,7 +257,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function() {
           self.callback(new Error('should not be called'));
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -217,7 +266,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -226,7 +275,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a valid request with algorithm set to "MD5"': {
     topic: function() {
       var strategy = new DigestStrategy({ algorithm: 'MD5' },
@@ -239,7 +288,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -250,7 +299,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function() {
           self.callback(new Error('should not be called'));
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -259,7 +308,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -268,7 +317,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a valid request with qop set to "auth"': {
     topic: function() {
       var strategy = new DigestStrategy({ qop: 'auth' },
@@ -285,7 +334,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -299,7 +348,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.error = function() {
           self.callback(new Error('should not be called'));
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -308,7 +357,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -317,7 +366,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a valid request with qop set to "auth" and equal sign in URL': {
     topic: function() {
       var strategy = new DigestStrategy({ qop: 'auth' },
@@ -334,7 +383,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -348,7 +397,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.error = function() {
           self.callback(new Error('should not be called'));
         }
-        
+
         req.url = '/sessions.json?sEcho=2&iColumns=12';
         req.method = 'HEAD';
         req.headers = {};
@@ -357,7 +406,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -366,7 +415,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a valid request with credentials not separated by spaces with qop set to "auth" and equal sign in URL': {
     topic: function() {
       var strategy = new DigestStrategy({ qop: 'auth' },
@@ -383,7 +432,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -397,7 +446,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.error = function() {
           self.callback(new Error('should not be called'));
         }
-        
+
         req.url = '/sessions.json?sEcho=2&iColumns=12';
         req.method = 'HEAD';
         req.headers = {};
@@ -406,7 +455,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -415,7 +464,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a valid request with qop set to "auth" and algorithm set to "MD5-sess"': {
     topic: function() {
       var strategy = new DigestStrategy({ qop: 'auth', algorithm: 'MD5-sess' },
@@ -428,7 +477,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -439,7 +488,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function() {
           self.callback(new Error('should not be called'));
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -448,7 +497,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -457,7 +506,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling an invalid request with qop set to "auth-int" and auth-int support not implemented': {
     topic: function() {
       var strategy = new DigestStrategy({ qop: 'auth-int' },
@@ -470,7 +519,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -484,7 +533,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.error = function(err) {
           self.callback(null, err);
         }
-        
+
         req.url = '/';
         req.method = 'POST';
         req.headers = {};
@@ -495,7 +544,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not call success or fail' : function(err, e) {
         assert.isNull(err);
       },
@@ -504,7 +553,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request with invalid password': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -517,7 +566,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -528,7 +577,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -537,7 +586,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with challenge' : function(err, challenge) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -545,7 +594,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request that does not have a shared secret': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -558,7 +607,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -569,7 +618,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -578,7 +627,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with challenge' : function(err, challenge) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -586,7 +635,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request that is not validated': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -599,7 +648,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -610,7 +659,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -619,7 +668,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with challenge' : function(err, challenge) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -627,7 +676,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request that encounters an error while finding shared secret': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -640,7 +689,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -654,7 +703,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.error = function(err) {
           self.callback(null, err);
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -663,7 +712,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not call success or fail' : function(err, e) {
         assert.isNull(err);
       },
@@ -672,7 +721,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request that encounters an error during validation': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -685,7 +734,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -699,7 +748,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.error = function(err) {
           self.callback(null, err);
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -708,7 +757,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not call success or fail' : function(err, e) {
         assert.isNull(err);
       },
@@ -717,7 +766,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request without authorization credentials': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -730,7 +779,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -741,14 +790,14 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.headers = {};
         process.nextTick(function () {
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with challenge' : function(err, challenge) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -756,7 +805,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request with non-Digest authorization credentials': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -769,7 +818,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -780,7 +829,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -789,7 +838,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with challenge' : function(err, challenge) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -797,7 +846,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request with malformed authorization header': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -810,7 +859,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -821,7 +870,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(status) {
           self.callback(null, status);
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -830,7 +879,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with 400 Bad Request' : function(err, status) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -838,7 +887,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request with malformed authorization credentials': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -851,7 +900,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -862,7 +911,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(status) {
           self.callback(null, status);
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -871,7 +920,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with 400 Bad Request' : function(err, status) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -879,7 +928,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request with non-matching uri': {
     topic: function() {
       var strategy = new DigestStrategy({ algorithm: 'MD5' },
@@ -892,7 +941,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -903,7 +952,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(status) {
           self.callback(null, status);
         }
-        
+
         req.url = '/admin';
         req.method = 'HEAD';
         req.headers = {};
@@ -912,7 +961,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with 400 Bad Request' : function(err, status) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -920,7 +969,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request with unknown algorithm': {
     topic: function() {
       var strategy = new DigestStrategy({ algorithm: 'MD5' },
@@ -933,7 +982,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -944,7 +993,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(status) {
           self.callback(null, status);
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -953,7 +1002,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with 400 Bad Request' : function(err, status) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -961,7 +1010,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request with unknown quality of protection': {
     topic: function() {
       var strategy = new DigestStrategy({ qop: 'auth' },
@@ -974,7 +1023,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -985,7 +1034,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(status) {
           self.callback(null, status);
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -994,7 +1043,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with 400 Bad Request' : function(err, status) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -1002,7 +1051,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request with DIGEST scheme in capitalized letters': {
     topic: function() {
       var strategy = new DigestStrategy(
@@ -1015,7 +1064,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -1026,7 +1075,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function() {
           self.callback(new Error('should not be called'));
         }
-        
+
         req.url = '/';
         req.method = 'HEAD';
         req.headers = {};
@@ -1035,7 +1084,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should not generate an error' : function(err, user) {
         assert.isNull(err);
       },
@@ -1044,7 +1093,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request that is not verified against specific realm': {
     topic: function() {
       var strategy = new DigestStrategy({ realm: 'Administrators' },
@@ -1057,7 +1106,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -1068,7 +1117,7 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.headers = {};
         req.headers.authorization = 'Digest username="bob", realm="Users", nonce="NOIEDJ3hJtqSKaty8KF8xlkaYbItAkiS", uri="/", response="22e3e0a9bbefeb9d229905230cb9ddc8"';
@@ -1076,7 +1125,7 @@ vows.describe('DigestStrategy').addBatch({
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with challenge' : function(err, challenge) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -1084,7 +1133,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request without authorization credentials with domain option set': {
     topic: function() {
       var strategy = new DigestStrategy({ domain: '/admin' },
@@ -1097,7 +1146,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -1108,14 +1157,14 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.headers = {};
         process.nextTick(function () {
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with challenge' : function(err, challenge) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -1123,7 +1172,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request without authorization credentials with multiple domain options set': {
     topic: function() {
       var strategy = new DigestStrategy({ domain: ['/admin', '/private'] },
@@ -1136,7 +1185,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -1147,14 +1196,14 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.headers = {};
         process.nextTick(function () {
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with challenge' : function(err, challenge) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -1162,7 +1211,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request without authorization credentials with opaque option set': {
     topic: function() {
       var strategy = new DigestStrategy({ opaque: 'abcdefg1234' },
@@ -1175,7 +1224,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -1186,14 +1235,14 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.headers = {};
         process.nextTick(function () {
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with challenge' : function(err, challenge) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -1201,7 +1250,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request without authorization credentials with algorithm option set': {
     topic: function() {
       var strategy = new DigestStrategy({ algorithm: 'MD5-sess' },
@@ -1214,7 +1263,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -1225,14 +1274,14 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.headers = {};
         process.nextTick(function () {
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with challenge' : function(err, challenge) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -1240,7 +1289,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request without authorization credentials with qop option set': {
     topic: function() {
       var strategy = new DigestStrategy({ qop: 'auth' },
@@ -1253,7 +1302,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -1264,14 +1313,14 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.headers = {};
         process.nextTick(function () {
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with challenge' : function(err, challenge) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -1279,7 +1328,7 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy handling a request without authorization credentials with multiple qop options set': {
     topic: function() {
       var strategy = new DigestStrategy({ qop: ['auth', 'auth-int'] },
@@ -1292,7 +1341,7 @@ vows.describe('DigestStrategy').addBatch({
       );
       return strategy;
     },
-    
+
     'after augmenting with actions': {
       topic: function(strategy) {
         var self = this;
@@ -1303,14 +1352,14 @@ vows.describe('DigestStrategy').addBatch({
         strategy.fail = function(challenge) {
           self.callback(null, challenge);
         }
-        
+
         req.url = '/';
         req.headers = {};
         process.nextTick(function () {
           strategy.authenticate(req);
         });
       },
-      
+
       'should fail authentication with challenge' : function(err, challenge) {
         // fail action was called, resulting in test callback
         assert.isNull(err);
@@ -1318,11 +1367,11 @@ vows.describe('DigestStrategy').addBatch({
       },
     },
   },
-  
+
   'strategy constructed without a secret callback or validate callback': {
     'should throw an error': function (strategy) {
       assert.throws(function() { new DigestStrategy() });
     },
   },
-  
+
 }).export(module);


### PR DESCRIPTION
The Authorization header's uri field is checked against request.url, which doesn't work for mounted apps.  This can be fixed by checking against request.originalUrl instead, when it is present.
