### PR TITLE
Decode user ID and password as URI components

### DIFF
--- a/lib/passport-http/strategies/basic.js
+++ b/lib/passport-http/strategies/basic.js
@@ -72,7 +72,7 @@ BasicStrategy.prototype.authenticate = function(req) {
   if (parts.length < 2) { return this.fail(400); }
   
   var scheme = parts[0]
-    , credentials = new Buffer(parts[1], 'base64').toString().split(':');
+    , credentials = new Buffer(parts[1], 'base64').toString().split(':').map(decodeURIComponent);
 
   if (!/Basic/i.test(scheme)) { return this.fail(this._challenge()); }
   if (credentials.length < 2) { return this.fail(400); }


### PR DESCRIPTION
The user ID and password must be encoded in order to [allow passwords that contain colons](https://github.com/jaredhanson/passport-http/issues/20).

Would it be appropriate to encode them as URI components, thus escaping the colon if there is one anywhere in the credentials?
