### PR TITLE
Added option disableBasicChallenge to disable WWW-Authenticate header.

### DIFF
--- a/lib/passport-http/strategies/basic.js
+++ b/lib/passport-http/strategies/basic.js
@@ -21,6 +21,7 @@ var passport = require('passport')
  *
  * Options:
  *   - `realm`  authentication realm, defaults to "Users"
+ *   - `disableBasicChallenge` disable WWW-Authenticate header, default false
  *
  * Examples:
  *
@@ -49,6 +50,7 @@ function BasicStrategy(options, verify) {
   this.name = 'basic';
   this._verify = verify;
   this._realm = options.realm || 'Users';
+  this._disableBasicChallenge = options.disableBasicChallenge;
   this._passReqToCallback = options.passReqToCallback;
 }
 
@@ -104,6 +106,7 @@ BasicStrategy.prototype.authenticate = function(req) {
  * @api private
  */
 BasicStrategy.prototype._challenge = function() {
+  if (this._disableBasicChallenge) { return 401 };
   return 'Basic realm="' + this._realm + '"';
 }
 


### PR DESCRIPTION
Setting this option to true will not send the header just a 401.
This is used to prevent native browser authentication popups.
