### PR TITLE
More explicit documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The HTTP Basic authentication strategy authenticates users using a userid and
 password.  The strategy requires a `verify` callback, which accepts these
 credentials and calls `done` providing a user.
 
+    var BasicStrategy = require('passport-http').BasicStrategy;
+
     passport.use(new BasicStrategy(
       function(userid, password, done) {
         User.findOne({ username: userid }, function (err, user) {


### PR DESCRIPTION
More explicit call to `require`, as we may be used to `require('module').Strategy` instead of `require('module').SomeStrategy`
