### PR TITLE
support express 4.x router nesting

### DIFF
--- a/lib/passport-http/strategies/digest.js
+++ b/lib/passport-http/strategies/digest.js
@@ -112,7 +112,9 @@ DigestStrategy.prototype.authenticate = function(req) {
   if (!creds.username) {
     return this.fail(this._challenge());
   }
-  if (req.url !== creds.uri) {
+
+  var url = req.originalUrl ? req.originalUrl : req.url;
+  if (url !== creds.uri) {
     return this.fail(400);
   }
   


### PR DESCRIPTION
When using express.Router() in express 4.x, req.url gets mucked with.  However, the original url is in req.originalUrl.  So use that if it exists, otherwise fallback to req.url.
