### PR TITLE
Fixed credentials breaking on passwords containing the character ':'.

### DIFF
--- a/lib/passport-http/strategies/basic.js
+++ b/lib/passport-http/strategies/basic.js
@@ -77,8 +77,8 @@ BasicStrategy.prototype.authenticate = function(req) {
   if (!/Basic/i.test(scheme)) { return this.fail(this._challenge()); }
   if (credentials.length < 2) { return this.fail(400); }
   
-  var userid = credentials[0];
-  var password = credentials[1];
+  var userid = credentials.shift();
+  var password = credentials.join(':');
   if (!userid || !password) {
     return this.fail(this._challenge());
   }


### PR DESCRIPTION
Fix for #41.
