### PR TITLE
Add auth info in basic callback

### DIFF
--- a/lib/passport-http/strategies/basic.js
+++ b/lib/passport-http/strategies/basic.js
@@ -85,10 +85,10 @@ BasicStrategy.prototype.authenticate = function(req) {
   
   var self = this;
   
-  function verified(err, user) {
+  function verified(err, user, info) {
     if (err) { return self.error(err); }
     if (!user) { return self.fail(self._challenge()); }
-    self.success(user);
+    self.success(user, info);
   }
   
   if (self._passReqToCallback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-http",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "HTTP Basic and Digest authentication strategies for Passport.",
   "keywords": ["passport", "http", "basic", "digest", "auth", "authn", "authentication"],
   "repository": {


### PR DESCRIPTION
Addresses issue #14 from upstream/master.  https://github.com/jaredhanson/passport-http/issues/14 