### PR TITLE
Now it works with Express 4+ relative urls

### DIFF
--- a/lib/passport-http/strategies/digest.js
+++ b/lib/passport-http/strategies/digest.js
@@ -112,7 +112,7 @@ DigestStrategy.prototype.authenticate = function(req) {
   if (!creds.username) {
     return this.fail(this._challenge());
   }
-  if (req.url !== creds.uri) {
+  if (((req.baseUrl?req.baseUrl:"")+req.url) !== creds.uri) {
     return this.fail(400);
   }
   


### PR DESCRIPTION
Hello,
I am proposing a little fix that adds req.baseUrl to the req.url to creds.uri checkup and this way allows the passport-http digest authentication to work fine with Express4 and 5 and especially with the relative urls it introduces.

If you build default project with Express4, you cannot simply add passport-http digest authentication to a sand-boxed route file, because digest.js verify req.uri to creds.uri. But req.uri is always relative while creds.uri is always full. Therefore the correct comparison is req.baseUrl+req.url == creds.uri.

This fix is quite simple and works very well to me, while it shall preserve compatibility with the old express versions.

Signed-off-by: Delian Delchev <delian.delchev@gmail.com>