### PR TITLE
Fix user name check.

### DIFF
--- a/lib/passport-http/strategies/digest.js
+++ b/lib/passport-http/strategies/digest.js
@@ -137,7 +137,7 @@ DigestStrategy.prototype.authenticate = function(req) {
       if (typeof password === 'object' && password.ha1) {
         ha1 = password.ha1;
       } else  {
-        ha1 = md5(creds.username + ":" + creds.realm + ":" + password);
+        ha1 = md5(user + ":" + creds.realm + ":" + password);
       }
     } else if (creds.algorithm === 'MD5-sess') {
       // TODO: The nonce and cnonce used here should be the initial nonce


### PR DESCRIPTION
The ha1 md5 need database user name to check user not use the user request name to check.