### PR TITLE
Fix failed auth if password contains a colon

### DIFF
--- a/lib/passport-http/strategies/basic.js
+++ b/lib/passport-http/strategies/basic.js
@@ -71,8 +71,9 @@ BasicStrategy.prototype.authenticate = function(req) {
   var parts = authorization.split(' ')
   if (parts.length < 2) { return this.fail(400); }
   
-  var scheme = parts[0]
-    , credentials = new Buffer(parts[1], 'base64').toString().split(':');
+  var scheme = parts[0], credstr = new Buffer(parts[1], 'base64').toString();
+  var credentials = [ credstr.substr(0, credstr.indexOf(":")),
+					  credstr.substr(credstr.indexOf(":")+1) ];
 
   if (!/Basic/i.test(scheme)) { return this.fail(this._challenge()); }
   if (credentials.length < 2) { return this.fail(400); }

--- a/lib/passport-http/strategies/basic.js
+++ b/lib/passport-http/strategies/basic.js
@@ -72,11 +72,10 @@ BasicStrategy.prototype.authenticate = function(req) {
   if (parts.length < 2) { return this.fail(400); }
   
   var scheme = parts[0], credstr = new Buffer(parts[1], 'base64').toString();
+  if (credstr.indexOf(":") === -1) { return this.fail(400); }
   var credentials = [ credstr.substr(0, credstr.indexOf(":")),
 					  credstr.substr(credstr.indexOf(":")+1) ];
-
   if (!/Basic/i.test(scheme)) { return this.fail(this._challenge()); }
-  if (credentials.length < 2) { return this.fail(400); }
   
   var userid = credentials[0];
   var password = credentials[1];


### PR DESCRIPTION
Authentification fails if the password contains a colon.
The RFC stipulate that the username can't contain a colon but the password can.
This change split the received authorization string only at the first colon found.

( sorry this is my first attempt to make a pull request ¯\_(ツ)_/¯ )