### PR TITLE
Fix url check error resulting in 400 when strategy is used in an Express router

### DIFF
--- a/lib/passport-http/strategies/digest.js
+++ b/lib/passport-http/strategies/digest.js
@@ -112,7 +112,7 @@ DigestStrategy.prototype.authenticate = function(req) {
   if (!creds.username) {
     return this.fail(this._challenge());
   }
-  if (req.url !== creds.uri) {
+  if (req.originalUrl !== creds.uri) {
     return this.fail(400);
   }
   


### PR DESCRIPTION
This happens because the Express router, changes the value of req.url to strip the mount point.
Using req.originalUrl should fix the issue ( Fixes #43 )
(see http://expressjs.com/en/4x/api.html#req.originalUrl for details)