### PR TITLE
README.md: code blocks with syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,18 @@ The HTTP Basic authentication strategy authenticates users using a userid and
 password.  The strategy requires a `verify` callback, which accepts these
 credentials and calls `done` providing a user.
 
-    passport.use(new BasicStrategy(
-      function(userid, password, done) {
-        User.findOne({ username: userid }, function (err, user) {
-          if (err) { return done(err); }
-          if (!user) { return done(null, false); }
-          if (!user.verifyPassword(password)) { return done(null, false); }
-          return done(null, user);
-        });
-      }
-    ));
+```JS
+passport.use(new BasicStrategy(
+  function(userid, password, done) {
+    User.findOne({ username: userid }, function (err, user) {
+      if (err) { return done(err); }
+      if (!user) { return done(null, false); }
+      if (!user.verifyPassword(password)) { return done(null, false); }
+      return done(null, user);
+    });
+  }
+));
+```
 
 #### Authenticate Requests
 
@@ -40,11 +42,13 @@ require session support, so the `session` option can be set to `false`.
 For example, as route middleware in an [Express](http://expressjs.com/)
 application:
 
-    app.get('/private', 
-      passport.authenticate('basic', { session: false }),
-      function(req, res) {
-        res.json(req.user);
-      });
+```JS
+app.get('/private', 
+  passport.authenticate('basic', { session: false }),
+  function(req, res) {
+    res.json(req.user);
+  });
+```
 
 #### Examples
 
@@ -64,19 +68,21 @@ The strategy also accepts an optional `validate` callback, which receives
 nonce-related `params` that can be further inspected to determine if the request
 is valid.
 
-    passport.use(new DigestStrategy({ qop: 'auth' },
-      function(username, done) {
-        User.findOne({ username: username }, function (err, user) {
-          if (err) { return done(err); }
-          if (!user) { return done(null, false); }
-          return done(null, user, user.password);
-        });
-      },
-      function(params, done) {
-        // validate nonces as necessary
-        done(null, true)
-      }
-    ));
+```JS
+passport.use(new DigestStrategy({ qop: 'auth' },
+  function(username, done) {
+    User.findOne({ username: username }, function (err, user) {
+      if (err) { return done(err); }
+      if (!user) { return done(null, false); }
+      return done(null, user, user.password);
+    });
+  },
+  function(params, done) {
+    // validate nonces as necessary
+    done(null, true)
+  }
+));
+```
 
 #### Authenticate Requests
 
@@ -87,11 +93,13 @@ require session support, so the `session` option can be set to `false`.
 For example, as route middleware in an [Express](http://expressjs.com/)
 application:
 
-    app.get('/private', 
-      passport.authenticate('digest', { session: false }),
-      function(req, res) {
-        res.json(req.user);
-      });
+```JS
+app.get('/private', 
+  passport.authenticate('digest', { session: false }),
+  function(req, res) {
+    res.json(req.user);
+  });
+```
 
 #### Examples
 


### PR DESCRIPTION
Use back-ticks around code blocks to enable proper syntax highlighting. Makes it easier to distinguish the given examples.