### PR TITLE
Handle basic credentials with colon character in the password.

### DIFF
--- a/lib/passport-http/strategies/basic.js
+++ b/lib/passport-http/strategies/basic.js
@@ -72,7 +72,7 @@ BasicStrategy.prototype.authenticate = function(req) {
   if (parts.length < 2) { return this.fail(400); }
   
   var scheme = parts[0]
-    , credentials = new Buffer(parts[1], 'base64').toString().split(':');
+    , credentials = new Buffer(parts[1], 'base64').toString().split(/:(.*)/);
 
   if (!/Basic/i.test(scheme)) { return this.fail(this._challenge()); }
   if (credentials.length < 2) { return this.fail(400); }

--- a/test/strategies/basic-test.js
+++ b/test/strategies/basic-test.js
@@ -440,4 +440,40 @@ vows.describe('BasicStrategy').addBatch({
     },
   },
 
+  'strategy handling a request containing a colon in the password': {
+    topic: function() {
+      var strategy = new BasicStrategy(function(userid, password, done) {
+        done(null, { username: userid, password: password });
+      });
+      return strategy;
+    },
+    
+    'after augmenting with actions': {
+      topic: function(strategy) {
+        var self = this;
+        var req = {};
+        strategy.success = function(user) {
+          self.callback(null, user);
+        }
+        strategy.fail = function() {
+          self.callback(new Error('should not be called'));
+        }
+        
+        req.headers = {};
+        req.headers.authorization = 'Basic Ym9iOnNlY3JldDpwYXNzd29yZA==';
+        process.nextTick(function () {
+          strategy.authenticate(req);
+        });
+      },
+      
+      'should not generate an error' : function(err, user) {
+        assert.isNull(err);
+      },
+      'should authenticate' : function(err, user) {
+        assert.equal(user.username, 'bob');
+        assert.equal(user.password, 'secret:password');
+      },
+    },
+  },
+
 }).export(module);


### PR DESCRIPTION
<!-- Provide a brief summary of the request in the title field above. -->

<!-- Provide a detailed description of your use case, including as much -->
<!-- detail as possible about what you are trying to accomplish and why. -->
<!-- If this patch closes an open issue, include a reference to the issue -->
<!-- number. -->

Per [RFC 2617 Section 2: Basic Authentication Scheme](https://tools.ietf.org/html/rfc2617#section-2), after decoding the basic authentication base64 credentials value, the `userid` is comprised of everything up to but not including the first `:` character, and the password is everything after that first `:` character. It seems that a strict reading would imply that passwords could themselves contain `:` characters as they would be part of the text that follows the first `:` character.
```
      user-pass   = userid ":" password
      userid      = *<TEXT excluding ":">
      password    = *TEXT
```

This patch (which closes issue #20) changes the behavior of the basic authentication strategy to more closely adhere to the RFC quoted above.

Previously it was splitting the base64 decoded string on the `:` character and using the 0th element as the username, the 1st element as the password, and dropping everything else, including part of the password if it contained another `:` character. After this patch it will only split the decoded value on the first `:` character and include everything afterwards in the password even if it contains additional `:` characters.

I have added a new test to verify that passwords with `:` characters now authenticate correctly. I have not added any new documentation as this is a pretty minor code change to fix a small problem and does not significantly add to or alter any existing functionality.

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport-http/blob/master/CONTRIBUTING.md) guidelines.
- [x] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [x] The automated test suite (`$ make test`) executes successfully.
- [x] The automated code linting (`$ make lint`) executes successfully.